### PR TITLE
Simplified build, multiplatform support and github actions builds

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+  push:
+
+jobs:
+  build-wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: pypa/cibuildwheel@v2.12.3
+      env:
+        CIBW_SKIP: cp36-*
+        CIBW_ARCHS_WINDOWS: auto64
+        CIBW_BEFORE_ALL_MACOS: "brew install llvm libomp"
+        CIBW_ENVIRONMENT_MACOS: CC="clang" CXX="clang++" PATH="/usr/local/opt/llvm/bin:$PATH" LDFLAGS="-L/usr/local/opt/llvm/lib" CPPFLAGS="-I/usr/local/opt/llvm/include"
+        CIBW_BEFORE_BUILD_MACOS: "clang --version"
+        CIBW_BUILD_VERBOSITY: 1
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 bin/
 build/
 dist/
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
-    "ninja",
-    "cmake>=3.12",
+    "pybind11"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,14 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 
 if sys.platform == "win32":
-    extra_compile_args = ["/Wall", "/arch:AVX"]
+    extra_compile_args = ["/Wall", "/arch:AVX", "/openmp"]  # /LTCG unrecognized here
+    extra_link_args = ["/LTCG"]  # /openmp unrecognized here
+elif sys.platform == "darwin":
+    extra_compile_args = ["-flto", "-Wall", "-march=native", "-mavx", "-fopenmp"]
+    extra_link_args = ["-fopenmp", "-lomp"]
 else:
-    extra_compile_args = ["-flto", "-Wall", "-march=native", "-mavx"]
+    extra_compile_args = ["-flto", "-Wall", "-march=native", "-mavx", "-fopenmp"]
+    extra_link_args = ["-fopenmp", "-lgomp"]
 
 ext_modules = [
     Pybind11Extension(
@@ -16,6 +21,7 @@ ext_modules = [
         include_dirs=["include"],
         cxx_std=17,
         extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,139 +1,39 @@
 import os
-import re
-import subprocess
 import sys
 
-from setuptools import Extension, setup
-from setuptools.command.build_ext import build_ext
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import setup
 
-# Convert distutils Windows platform specifiers to CMake -A arguments
-PLAT_TO_CMAKE = {
-    "win32": "Win32",
-    "win-amd64": "x64",
-    "win-arm32": "ARM",
-    "win-arm64": "ARM64",
-}
+if sys.platform == "win32":
+    extra_compile_args = ["/Wall", "/arch:AVX"]
+else:
+    extra_compile_args = ["-flto", "-Wall", "-march=native", "-mavx"]
 
+ext_modules = [
+    Pybind11Extension(
+        "pyvptree",
+        ["src/PythonBindings.cpp"],
+        include_dirs=["include"],
+        cxx_std=17,
+        extra_compile_args=extra_compile_args,
+    ),
+]
 
-# A CMakeExtension needs a sourcedir instead of a file list.
-# The name must be the _single_ output extension from the CMake build.
-# If you need multiple extensions, see scikit-build.
-class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=""):
-        Extension.__init__(self, name, sources=[])
-        self.sourcedir = os.path.abspath(sourcedir)
+with open("README.md", "rt", encoding="utf-8") as fr:
+    long_description = fr.read()
 
-
-class CMakeBuild(build_ext):
-    def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-
-        # required for auto-detection & inclusion of auxiliary "native" libs
-        if not extdir.endswith(os.path.sep):
-            extdir += os.path.sep
-
-        debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
-        cfg = "Debug" if debug else "Release"
-
-        # CMake lets you override the generator - we need to check this.
-        # Can be set with Conda-Build, for example.
-        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
-        cxx_flags = os.environ.get("CXX_FLAGS", "-flto -Wall -march=native -mavx")
-
-        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
-        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
-        # from Python.
-        cmake_args = [
-            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}",
-            f"-DPYTHON_EXECUTABLE={sys.executable}",
-            f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
-            f"-DCMAKE_CXX_FLAGS={cxx_flags}",  # not used on MSVC, but no harm
-        ]
-        build_args = []
-        # Adding CMake arguments set as environment variable
-        # (needed e.g. to build for ARM OSx on conda-forge)
-        if "CMAKE_ARGS" in os.environ:
-            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
-
-        # In this example, we pass in the version to C++. You might not need to.
-        cmake_args += [f"-DEXAMPLE_VERSION_INFO={self.distribution.get_version()}"]
-
-        if self.compiler.compiler_type != "msvc":
-            # Using Ninja-build since it a) is available as a wheel and b)
-            # multithreads automatically. MSVC would require all variables be
-            # exported for Ninja to pick it up, which is a little tricky to do.
-            # Users can override the generator with CMAKE_GENERATOR in CMake
-            # 3.15+.
-            if not cmake_generator:
-                try:
-                    import ninja  # noqa: F401
-
-                    cmake_args += ["-GNinja"]
-                except ImportError:
-                    pass
-
-        else:
-
-            # Single config generators are handled "normally"
-            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
-
-            # CMake allows an arch-in-generator style for backward compatibility
-            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
-
-            # Specify the arch if using MSVC generator, but only if it doesn't
-            # contain a backward-compatibility arch spec already in the
-            # generator name.
-            if not single_config and not contains_arch:
-                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
-
-            # Multi-config generators have a different way to specify configs
-            if not single_config:
-                cmake_args += [
-                    f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}={extdir}"
-                ]
-                build_args += ["--config", cfg]
-
-        if sys.platform.startswith("darwin"):
-            # Cross-compile support for macOS - respect ARCHFLAGS if set
-            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
-            if archs:
-                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
-
-        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
-        # across all generators.
-        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
-            # self.parallel is a Python 3 only way to set parallel jobs by hand
-            # using -j in the build_ext call, not supported by pip or PyPA-build.
-            if hasattr(self, "parallel") and self.parallel:
-                # CMake 3.12+ only.
-                build_args += [f"-j{self.parallel}"]
-
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
-
-        subprocess.check_call(
-            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
-        )
-        subprocess.check_call(
-            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
-        )
-
-
-# The information here can also be placed in setup.cfg - better separation of
-# logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="pyvptree",
     version="0.0.1",
     author="Pablo Carneiro Elias",
     author_email="pablo.cael@gmail.com",
     description="An efficient implementation of Vantage Point Tree for Python 3",
-    long_description="",
-    ext_modules=[CMakeExtension("pyvptree")],
-    cmdclass={"build_ext": CMakeBuild},
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    ext_modules=ext_modules,
     zip_safe=False,
-    install_requires=[
-       'numpy>=1.21.2'
-    ],
+    install_requires=["numpy>=1.21.2"],
     extras_require={"test": ["pytest>=6.0"]},
     python_requires=">=3.6",
+    license_files=("LICENSE",),
 )

--- a/src/PythonBindings.cpp
+++ b/src/PythonBindings.cpp
@@ -8,7 +8,12 @@
 #include <pybind11/stl.h>
 #include <VPTree.hpp>
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
 #include <nmmintrin.h>
+#endif
+
 #include <stdint.h>
 #include <omp.h>
 #include <immintrin.h>


### PR DESCRIPTION
- Windows, Mac and Linux build on Github actions now
- for python wheels I completely removed the cmake build system and replaced it with a very simply pybind setup
- adjusted some header files and compiler/linker flags

However some tests always fail currently. They will succeed when https://github.com/pablocael/pyvptree/pull/8 and https://github.com/pablocael/pyvptree/pull/9 are merged as well.

You can see the github actions run here <https://github.com/Dobatymo/pyvptree/actions/runs/5413130146>