### PR TITLE
feat: make cmake function to allow cpp dbg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ test:
 	export PYTHONPATH=$PWD
 	pytest pyvptree/tests
 
+.PHONY: cpp-test
+cpp-test:
+	mkdir -p build && cd build && cmake -G "Unix Makefiles" ../pyvptree && make && make test
+
 .PHONY: benchmarks
 benchmarks:
 	export PYTHONPATH=$PWD

--- a/README.md
+++ b/README.md
@@ -72,10 +72,32 @@ To customize or regenerate the benchmarks as well as to see other benchmark resu
 
 # Development
 
-## Running tests
+## Running Python Tests
 
 ```
 make test
+```
+
+## Debugging and Running C++ Code
+
+For debugging and running C++ code independently from python module, CMake config files are provided in pyvptree/CMakeLists.txt.
+For generating C++ makefiles and building tests run:
+
+```
+mkdir build
+cmake -G "Unix Makefiles" ../pyvptree
+make
+```
+
+For running C++ tests:
+```
+./tests/vptree-tests
+```
+
+Since tests are built in Debug mode (defualt CMakeLists build mode), one can debug tests with gdb:
+
+```
+gdb ./tests/vptree-tests
 ```
 
 ## Formating code

--- a/README.md
+++ b/README.md
@@ -81,23 +81,17 @@ make test
 ## Debugging and Running C++ Code
 
 For debugging and running C++ code independently from python module, CMake config files are provided in pyvptree/CMakeLists.txt.
-For generating C++ makefiles and building tests run:
+For building and running C++ tests run:
 
 ```
-mkdir build
-cmake -G "Unix Makefiles" ../pyvptree
-make
-```
-
-For running C++ tests:
-```
-./tests/vptree-tests
-```
-
-Since tests are built in Debug mode (defualt CMakeLists build mode), one can debug tests with gdb:
+make cpp-test
 
 ```
-gdb ./tests/vptree-tests
+
+Since tests are built in Debug mode (default CMakeLists build mode), one can debug tests with gdb using built test binary:
+
+```
+gdb ./build/tests/vptree-tests
 ```
 
 ## Formating code

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To customize or regenerate the benchmarks as well as to see other benchmark resu
 make test
 ```
 
-## Debugging and Running C++ Code
+## Debugging and Running C++ Code on Unix
 
 For debugging and running C++ code independently from python module, CMake config files are provided in pyvptree/CMakeLists.txt.
 For building and running C++ tests run:

--- a/pyvptree/CMakeLists.txt
+++ b/pyvptree/CMakeLists.txt
@@ -10,7 +10,19 @@ find_package(PythonLibs REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(OpenMP)
 
-set(DEFAULT_BUILD_TYPE "Release")
+set(DEFAULT_BUILD_TYPE "Debug")
+
+if(WIN32)
+    SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /Wall /arch:AVX /openmp")
+    SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
+else()
+    SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -flto -Wall -march=native -mavx -fopenmp")
+    if(APPLE)
+        SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -fopenmp -lomp")
+    else()
+        SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -fopenmp -lgomp")
+    endif()
+endif(WIN32)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to '${DEFAULT_BUILD_TYPE}' as none was specified.")
@@ -32,7 +44,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION 1)
-set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/VPTree.hpp", "${CMAKE_CURRENT_SOURCE_DIR}/include/DistanceFunctions.hpp")
+set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/VPTree.hpp ${CMAKE_CURRENT_SOURCE_DIR}/include/DistanceFunctions.hpp")
 
 set(CONFIG_NAME ${PROJECT_NAME}Config)
 

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -110,7 +110,7 @@ TEST(VPTests, TestCreation) {
     std::cout << "Building tree with " << numPoints << " points " << std::endl;
     auto start = std::chrono::steady_clock::now();
 
-    VPTree<Eigen::Vector3d, distance> tree(points);
+    VPTree<Eigen::Vector3d, float, distance> tree(points);
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<float> diff = end - start;
     std::cout << "Process took" << diff.count() << " seconds " << std::endl;
@@ -134,7 +134,7 @@ TEST(VPTests, TestSearch) {
     std::cout << "Building tree with " << numPoints << " points " << std::endl;
     auto start = std::chrono::steady_clock::now();
 
-    VPTree<Eigen::Vector3d, distance> tree(points);
+    VPTree<Eigen::Vector3d, float, distance> tree(points);
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<float> diff = end - start;
     std::cout << "Process took " << diff.count() << " seconds " << std::endl;
@@ -148,7 +148,7 @@ TEST(VPTests, TestSearch) {
         point[1] = distribution(generator);
         point[2] = distribution(generator);
     }
-    /* std::vector<VPTree<Eigen::Vector3d,distance>::VPTreeSearchResultElement> results; */
+    /* std::vector<VPTree<Eigen::Vector3d, float, distance>::VPTreeSearchResultElement> results; */
     std::vector<unsigned int> indices;
     std::vector<float> distances;
     start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Cmake did not have proper compiler and linker flags to allow compiling tests.

Added proper flags so one can generate CMake makefile project and debug cpp code.