### PR TITLE
Fix/severe mem bug

### DIFF
--- a/pyvptree/include/ISerializable.hpp
+++ b/pyvptree/include/ISerializable.hpp
@@ -83,7 +83,7 @@ class ISerializable {
 };
 
 std::ostream &operator<<(std::ostream &os, const SerializedState &state) {
-    for (int i = 0; i < state.data.size(); i++) {
+    for (size_t i = 0; i < state.data.size(); i++) {
         os << state.data[i];
     }
     os << std::endl;

--- a/pyvptree/include/VPLevelPartition.hpp
+++ b/pyvptree/include/VPLevelPartition.hpp
@@ -11,7 +11,6 @@
 
 #include "ISerializable.hpp"
 
-#define ENABLE_OMP_PARALLEL 1
 namespace vptree {
 
 template <typename distance_type> class VPLevelPartition : public ISerializable {

--- a/pyvptree/include/VPLevelPartition.hpp
+++ b/pyvptree/include/VPLevelPartition.hpp
@@ -1,0 +1,159 @@
+
+#pragma once
+
+#include <iostream>
+#include <limits>
+#include <queue>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include "ISerializable.hpp"
+
+#define ENABLE_OMP_PARALLEL 1
+namespace vptree {
+
+template <typename distance_type> class VPLevelPartition {
+    public:
+    VPLevelPartition(distance_type radius, unsigned int start, unsigned int end) {
+        // For each partition, the vantage point is the first point within the partition (pointed by indexStart)
+
+        _radius = radius;
+        _indexStart = start;
+        _indexEnd = end;
+    }
+
+    VPLevelPartition() {
+        // Constructs an empty level
+
+        _radius = 0;
+        _indexStart = -1;
+        _indexEnd = -1;
+    }
+
+    virtual ~VPLevelPartition() { clear(); }
+
+    SerializedState serialize() const {
+
+        SerializedState state;
+        std::vector<const VPLevelPartition *> flatten_tree_state;
+
+        flatten_tree(this, flatten_tree_state);
+
+        size_t total_size = flatten_tree_state.size() * (2 * sizeof(int64_t) + sizeof(float));
+        state.data.resize(total_size);
+
+        uint8_t *buffer = &state.data[0];
+        uint8_t *p_buffer = buffer;
+
+        // reverse the tree state since we will push it in a stack for serializing
+        for (const VPLevelPartition *elem : flatten_tree_state) {
+            if (elem == nullptr) {
+                (*(int64_t *)(p_buffer)) = (int64_t)(-1);
+                p_buffer += sizeof(int64_t);
+                (*(int64_t *)(p_buffer)) = (int64_t)(-1);
+                p_buffer += sizeof(int64_t);
+                (*(float *)(p_buffer)) = (float)(-1);
+                p_buffer += sizeof(float);
+                continue;
+            }
+            (*(int64_t *)(p_buffer)) = (int64_t)(elem->_indexEnd);
+            p_buffer += sizeof(int64_t);
+            (*(int64_t *)(p_buffer)) = (int64_t)(elem->_indexStart);
+            p_buffer += sizeof(int64_t);
+            (*(float *)(p_buffer)) = (float)(elem->_radius);
+            p_buffer += sizeof(float);
+        }
+
+        if ((size_t)(p_buffer - buffer) != total_size) {
+            throw new std::out_of_range("invalid serialization state, offsets dont match!");
+        }
+
+        return state;
+    }
+
+    void deserialize(const SerializedState &state, uint32_t offset) {
+        clear();
+
+        uint8_t *p_buffer = (&const_cast<std::vector<uint8_t> &>(state.data)[0]) + offset;
+        VPLevelPartition *recovered = rebuild_from_state(&p_buffer);
+        if (recovered == nullptr) {
+            return;
+        }
+
+        _left = recovered->_left;
+        _right = recovered->_right;
+        _radius = recovered->_radius;
+        _indexStart = recovered->_indexStart;
+        _indexEnd = recovered->_indexEnd;
+    }
+
+    bool isEmpty() { return _radius == 0; }
+    unsigned int start() { return _indexStart; }
+    unsigned int end() { return _indexEnd; }
+    unsigned int size() { return _indexEnd - _indexStart + 1; }
+    void setRadius(distance_type radius) { _radius = radius; }
+    distance_type radius() { return _radius; }
+
+    void setChild(VPLevelPartition<distance_type> *left, VPLevelPartition<distance_type> *right) {
+        _left = left;
+        _right = right;
+    }
+
+    VPLevelPartition *left() const { return _left; }
+    VPLevelPartition *right() const { return _right; }
+
+    private:
+    void clear() {
+        if (_left != nullptr)
+            delete _left;
+
+        if (_right != nullptr)
+            delete _right;
+
+        _left = nullptr;
+        _right = nullptr;
+    }
+
+    void flatten_tree(const VPLevelPartition *root, std::vector<const VPLevelPartition *> &flatten_tree_state) const {
+        // visit partitions tree in preorder push all values.
+        flatten_tree_state.push_back(root);
+        if (root != nullptr) {
+            flatten_tree(root->left(), flatten_tree_state);
+            flatten_tree(root->right(), flatten_tree_state);
+        }
+    }
+
+    VPLevelPartition *rebuild_from_state(uint8_t **p_buffer) {
+        int64_t indexEnd = (*(int64_t *)(*p_buffer));
+        *p_buffer += sizeof(int64_t);
+        int64_t indexStart = (*(int64_t *)(*p_buffer));
+        *p_buffer += sizeof(int64_t);
+        float radius = (*(float *)(*p_buffer));
+        *p_buffer += sizeof(float);
+
+        if (indexEnd == -1) {
+            return nullptr;
+        }
+
+        VPLevelPartition *root = new VPLevelPartition(radius, (unsigned int)indexStart, (unsigned int)indexEnd);
+        VPLevelPartition *left = rebuild_from_state(p_buffer);
+        VPLevelPartition *right = rebuild_from_state(p_buffer);
+        root->setChild(left, right);
+        return root;
+    }
+
+    distance_type _radius;
+
+    // _indexStart and _indexEnd are index pointers to examples within the examples list, not index of coordinates
+    // within the coordinate buffer.For instance, _indexEnd pointing to last element of a coordinate buffer of 9 entries
+    // (3 examples of 3 dimensions each) would be pointing to 2, which is the index of the 3rd element.
+    // If _indexStart == _indexEnd then the level contains only one element.
+    unsigned int _indexStart; // points to the first of the example in which this level starts
+    unsigned int _indexEnd;
+
+    VPLevelPartition<distance_type> *_left = nullptr;
+    VPLevelPartition<distance_type> *_right = nullptr;
+};
+
+};

--- a/pyvptree/include/VPLevelPartition.hpp
+++ b/pyvptree/include/VPLevelPartition.hpp
@@ -15,7 +15,7 @@ namespace vptree {
 
 template <typename distance_type> class VPLevelPartition {
     public:
-    VPLevelPartition(distance_type radius, unsigned int start, unsigned int end) {
+    VPLevelPartition(distance_type radius, int64_t start, int64_t end) {
         // For each partition, the vantage point is the first point within the partition (pointed by indexStart)
 
         _radius = radius;
@@ -88,10 +88,10 @@ template <typename distance_type> class VPLevelPartition {
         _indexEnd = recovered->_indexEnd;
     }
 
-    bool isEmpty() { return _radius == 0; }
-    unsigned int start() { return _indexStart; }
-    unsigned int end() { return _indexEnd; }
-    unsigned int size() { return _indexEnd - _indexStart + 1; }
+    bool isEmpty() { return _indexStart == -1; }
+    int64_t start() { return _indexStart; }
+    int64_t end() { return _indexEnd; }
+    int64_t size() { return _indexEnd - _indexStart + 1; }
     void setRadius(distance_type radius) { _radius = radius; }
     distance_type radius() { return _radius; }
 
@@ -136,7 +136,7 @@ template <typename distance_type> class VPLevelPartition {
             return nullptr;
         }
 
-        VPLevelPartition *root = new VPLevelPartition(radius, (unsigned int)indexStart, (unsigned int)indexEnd);
+        VPLevelPartition *root = new VPLevelPartition(radius, indexStart, indexEnd);
         VPLevelPartition *left = rebuild_from_state(p_buffer);
         VPLevelPartition *right = rebuild_from_state(p_buffer);
         root->setChild(left, right);
@@ -145,12 +145,13 @@ template <typename distance_type> class VPLevelPartition {
 
     distance_type _radius;
 
-    // _indexStart and _indexEnd are index pointers to examples within the examples list, not index of coordinates
-    // within the coordinate buffer.For instance, _indexEnd pointing to last element of a coordinate buffer of 9 entries
-    // (3 examples of 3 dimensions each) would be pointing to 2, which is the index of the 3rd element.
+    // _indexStart and _indexEnd are index pointers to examples within the examples list of the VPTre, not index of coordinates
+    // within the coordinate buffer. For instance, if _indexEnd pointing to last element of a coordinate buffer of 9 entries
+    // (3 examples of 3 dimensions each), then it would be pointing to 2, which is the index of the 3rd element.
     // If _indexStart == _indexEnd then the level contains only one element.
-    unsigned int _indexStart; // points to the first of the example in which this level starts
-    unsigned int _indexEnd;
+    // If _indexStart == -1 then the level is empty.
+    int64_t _indexStart; // points to the first of the example in which this level starts
+    int64_t _indexEnd;
 
     VPLevelPartition<distance_type> *_left = nullptr;
     VPLevelPartition<distance_type> *_right = nullptr;

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -192,7 +192,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
             searchKNN(_rootPartition, query, k, knnQueue);
 
             // we must always return k elements for each search unless there is no k elements
-            assert(static_cast<size_t>(knnQueue.size()) == std::min<size_t>(_examples.size(), k));
+            assert(knnQueue.size() == std::min<size_t>(_examples.size(), k));
 
             fillSearchResult(knnQueue, results[i]);
         }

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -55,9 +55,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         deserialize(other_state);
     }
 
-	const VPTree<T, distance_type, distance> &operator= (const VPTree<T, distance_type, distance> &other) {
-        this->deserialize(other.serialize());
-    }
+    const VPTree<T, distance_type, distance> &operator=(const VPTree<T, distance_type, distance> &other) { this->deserialize(other.serialize()); }
 
     ~VPTree() { clear(); };
 
@@ -185,7 +183,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         results.resize(queries.size());
 
 #if (ENABLE_OMP_PARALLEL)
-#pragma omp parallel for schedule(static, 1) num_threads(16)
+#pragma omp parallel for schedule(static, 1)
 #endif
         // i should be size_t, however msvc requires signed integral loop variables (except with -openmp:llvm)
         for (int i = 0; i < queries.size(); ++i) {
@@ -212,7 +210,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         distances.resize(queries.size());
 
 #if (ENABLE_OMP_PARALLEL)
-#pragma omp parallel for schedule(static, 1) num_threads(16)
+#pragma omp parallel for schedule(static, 1)
 #endif
         // i should be size_t, see above
         for (int i = 0; i < queries.size(); ++i) {

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -177,7 +177,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         _rootPartition->deserialize(copy);
     }
 
-    void searchKNN(const std::vector<T> &queries, unsigned int k, std::vector<VPTreeSearchResultElement> &results) {
+    void searchKNN(const std::vector<T> &queries, size_t k, std::vector<VPTreeSearchResultElement> &results) {
 
         if (isEmpty()) {
             throw std::runtime_error("index must be first initialized with .set() function and non empty dataset");

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -189,7 +189,18 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
 
     VPTree() = default;
 
+    ~VPTree() { clear(); };
+
+    void clear() {
+        if (_rootPartition != nullptr) {
+            delete _rootPartition;
+        }
+        _rootPartition = nullptr;
+        _examples.clear();
+    }
+
     VPTree(const std::vector<T> &array) {
+        clear();
 
         _examples.reserve(array.size());
         _examples.resize(array.size());

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -22,7 +22,7 @@
 #include "ISerializable.hpp"
 #include "VPLevelPartition.hpp"
 
-#define ENABLE_OMP_PARALLEL 0
+#define ENABLE_OMP_PARALLEL 1
 
 namespace vptree {
 

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -223,6 +223,30 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         }
     }
 
+    friend std::ostream &operator<<(std::ostream &os, const VPTree<T, distance_type, distance> &vptree) {
+        os << "####################" << std::endl;
+        os << "# [VPTree state]" << std::endl;
+        os << "Num Data Points: " << vptree._examples.size() << std::endl;
+
+        int64_t total_memory = 0;
+        if (vptree._rootPartition != nullptr) {
+            total_memory =
+                vptree._rootPartition->numSubnodes() * sizeof(VPLevelPartition<distance_type>) + vptree._examples.size() * sizeof(VPTreeElement);
+        }
+        os << "Total Memory: " << total_memory << " bytes" << std::endl;
+        os << "####################" << std::endl;
+        os << "[+] Root Level:" << std::endl;
+        if (vptree._rootPartition != nullptr) {
+            total_memory =
+                vptree._rootPartition->numSubnodes() * sizeof(VPLevelPartition<distance_type>) + vptree._examples.size() * sizeof(VPTreeElement);
+            os << *vptree._rootPartition << std::endl;
+        } else {
+            os << "<empty>" << std::endl;
+        }
+
+        return os;
+    }
+
     protected:
     /*
      *  Builds a Vantage Point tree using each element of the given array as one coordinate buffer

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -211,6 +211,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         build(_examples);
     }
 
+    bool isEmpty() { return _rootPartition == nullptr; }
     SerializedState serialize() const override {
         if (_rootPartition == nullptr) {
             return SerializedState();

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -175,8 +175,8 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
 
     void searchKNN(const std::vector<T> &queries, unsigned int k, std::vector<VPTreeSearchResultElement> &results) {
 
-        if (_rootPartition == nullptr) {
-            return;
+        if (isEmpty()) {
+            throw std::runtime_error("indices must be first initialized with .set() function");
         }
 
         // we must return one result per queries
@@ -201,8 +201,8 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
     // An optimized version for 1 NN search
     void search1NN(const std::vector<T> &queries, std::vector<int64_t> &indices, std::vector<distance_type> &distances) {
 
-        if (_rootPartition == nullptr) {
-            return;
+        if (isEmpty()) {
+            throw std::runtime_error("indices must be first initialized with .set() function");
         }
 
         // we must return one result per queries

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -55,6 +55,10 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         deserialize(other_state);
     }
 
+	const VPTree<T, distance_type, distance> &operator= (const VPTree<T, distance_type, distance> &other) {
+        this->deserialize(other.serialize());
+    }
+
     ~VPTree() { clear(); };
 
     void clear() {

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -72,6 +72,10 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
     void set(const std::vector<T> &array) {
         clear();
 
+        if(array.empty()) {
+            return;
+        }
+
         _examples.reserve(array.size());
         _examples.resize(array.size());
         for (size_t i = 0; i < array.size(); ++i) {
@@ -176,7 +180,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
     void searchKNN(const std::vector<T> &queries, unsigned int k, std::vector<VPTreeSearchResultElement> &results) {
 
         if (isEmpty()) {
-            throw std::runtime_error("indices must be first initialized with .set() function");
+            throw std::runtime_error("index must be first initialized with .set() function and non empty dataset");
         }
 
         // we must return one result per queries
@@ -202,7 +206,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
     void search1NN(const std::vector<T> &queries, std::vector<int64_t> &indices, std::vector<distance_type> &distances) {
 
         if (isEmpty()) {
-            throw std::runtime_error("indices must be first initialized with .set() function");
+            throw std::runtime_error("index must be first initialized with .set() function and non empty dataset");
         }
 
         // we must return one result per queries

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -200,6 +200,11 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
     }
 
     VPTree(const std::vector<T> &array) {
+        set(array);
+    
+    }
+
+    void set(const std::vector<T> &array) {
         clear();
 
         _examples.reserve(array.size());
@@ -271,6 +276,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
             delete _rootPartition;
             _rootPartition = nullptr;
         }
+        clear();
         if (state.data.empty()) {
             return;
         }

--- a/pyvptree/include/VPTree.hpp
+++ b/pyvptree/include/VPTree.hpp
@@ -20,153 +20,11 @@
 #include <vector>
 
 #include "ISerializable.hpp"
+#include "VPLevelPartition.hpp"
 
 #define ENABLE_OMP_PARALLEL 1
 
 namespace vptree {
-
-template <typename distance_type> class VPLevelPartition {
-    public:
-    VPLevelPartition(distance_type radius, unsigned int start, unsigned int end) {
-        // For each partition, the vantage point is the first point within the partition (pointed by indexStart)
-
-        _radius = radius;
-        _indexStart = start;
-        _indexEnd = end;
-    }
-
-    VPLevelPartition() {
-        // Constructs an empty level
-
-        _radius = 0;
-        _indexStart = -1;
-        _indexEnd = -1;
-    }
-
-    virtual ~VPLevelPartition() { clear(); }
-
-    SerializedState serialize() const {
-
-        SerializedState state;
-        std::vector<const VPLevelPartition *> flatten_tree_state;
-
-        flatten_tree(this, flatten_tree_state);
-
-        size_t total_size = flatten_tree_state.size() * (2 * sizeof(int64_t) + sizeof(float));
-        state.data.resize(total_size);
-
-        uint8_t *buffer = &state.data[0];
-        uint8_t *p_buffer = buffer;
-
-        // reverse the tree state since we will push it in a stack for serializing
-        for (const VPLevelPartition *elem : flatten_tree_state) {
-            if (elem == nullptr) {
-                (*(int64_t *)(p_buffer)) = (int64_t)(-1);
-                p_buffer += sizeof(int64_t);
-                (*(int64_t *)(p_buffer)) = (int64_t)(-1);
-                p_buffer += sizeof(int64_t);
-                (*(float *)(p_buffer)) = (float)(-1);
-                p_buffer += sizeof(float);
-                continue;
-            }
-            (*(int64_t *)(p_buffer)) = (int64_t)(elem->_indexEnd);
-            p_buffer += sizeof(int64_t);
-            (*(int64_t *)(p_buffer)) = (int64_t)(elem->_indexStart);
-            p_buffer += sizeof(int64_t);
-            (*(float *)(p_buffer)) = (float)(elem->_radius);
-            p_buffer += sizeof(float);
-        }
-
-        if ((size_t)(p_buffer - buffer) != total_size) {
-            throw new std::out_of_range("invalid serialization state, offsets dont match!");
-        }
-
-        return state;
-    }
-
-    void deserialize(const SerializedState &state, uint32_t offset) {
-        clear();
-
-        uint8_t *p_buffer = (&const_cast<std::vector<uint8_t> &>(state.data)[0]) + offset;
-        VPLevelPartition *recovered = rebuild_from_state(&p_buffer);
-        if (recovered == nullptr) {
-            return;
-        }
-
-        _left = recovered->_left;
-        _right = recovered->_right;
-        _radius = recovered->_radius;
-        _indexStart = recovered->_indexStart;
-        _indexEnd = recovered->_indexEnd;
-    }
-
-    bool isEmpty() { return _indexStart == -1 || _indexStart == -1; }
-    unsigned int start() { return _indexStart; }
-    unsigned int end() { return _indexEnd; }
-    unsigned int size() { return _indexEnd - _indexStart + 1; }
-    void setRadius(distance_type radius) { _radius = radius; }
-    distance_type radius() { return _radius; }
-
-    void setChild(VPLevelPartition<distance_type> *left, VPLevelPartition<distance_type> *right) {
-        _left = left;
-        _right = right;
-    }
-
-    VPLevelPartition *left() const { return _left; }
-    VPLevelPartition *right() const { return _right; }
-
-    private:
-    void clear() {
-        if (_left != nullptr)
-            delete _left;
-
-        if (_right != nullptr)
-            delete _right;
-
-        _left = nullptr;
-        _right = nullptr;
-    }
-
-    void flatten_tree(const VPLevelPartition *root, std::vector<const VPLevelPartition *> &flatten_tree_state) const {
-        // visit partitions tree in preorder push all values.
-        flatten_tree_state.push_back(root);
-        if (root != nullptr) {
-            flatten_tree(root->left(), flatten_tree_state);
-            flatten_tree(root->right(), flatten_tree_state);
-        }
-    }
-
-    VPLevelPartition *rebuild_from_state(uint8_t **p_buffer) {
-        int64_t indexEnd = (*(int64_t *)(*p_buffer));
-        *p_buffer += sizeof(int64_t);
-        int64_t indexStart = (*(int64_t *)(*p_buffer));
-        *p_buffer += sizeof(int64_t);
-        float radius = (*(float *)(*p_buffer));
-        *p_buffer += sizeof(float);
-
-        if (indexEnd == -1) {
-            return nullptr;
-        }
-
-        VPLevelPartition *root = new VPLevelPartition(radius, (unsigned int)indexStart, (unsigned int)indexEnd);
-        VPLevelPartition *left = rebuild_from_state(p_buffer);
-        VPLevelPartition *right = rebuild_from_state(p_buffer);
-        root->setChild(left, right);
-        return root;
-    }
-
-    distance_type _radius;
-
-    // _indexStart and _indexEnd are index pointers to examples within the examples list, not index of coordinates
-    // within the coordinate buffer.For instance, _indexEnd pointing to last element of a coordinate buffer of 9 entries
-    // (3 examples of 3 dimensions each) would be pointing to 2, which is the index of the 3rd element.
-    // If _indexStart == _indexEnd then the level contains only one element.
-    unsigned int _indexStart; // points to the first of the example in which this level starts
-    unsigned int _indexEnd;
-
-    VPLevelPartition<distance_type> *_left = nullptr;
-    VPLevelPartition<distance_type> *_right = nullptr;
-};
 
 template <typename T, typename distance_type, distance_type (*distance)(const T &, const T &)> class VPTree : public ISerializable {
     public:
@@ -187,7 +45,10 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
         std::vector<distance_type> distances;
     };
 
-    VPTree() = default;
+    VPTree() {
+        _rootPartition = nullptr;
+        _examples.clear();
+    }
 
     ~VPTree() { clear(); };
 

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -22,34 +22,20 @@ typedef float (*distance_func_f)(const arrayf &, const arrayf &);
 
 template <distance_func_f distance> class VPTreeNumpyAdapter {
     public:
-    VPTreeNumpyAdapter() { setEmpty(); }
-    ~VPTreeNumpyAdapter() { clear(); }
+    VPTreeNumpyAdapter() = default;
 
     void set(const ndarrayf &array) {
-        clear();
-        tree = new vptree::VPTree<arrayf, float, distance>(array);
-    }
-
-    void setEmpty() {
-        clear();
-        tree = new vptree::VPTree<arrayf, float, distance>();
-    }
-
-    void clear() {
-        if (tree != nullptr) {
-            delete tree;
-        }
-        tree = nullptr;
+        tree.set(array);
     }
 
     std::tuple<std::vector<std::vector<unsigned int>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
 
-        if (tree == nullptr) {
+        if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
 
         std::vector<typename vptree::VPTree<arrayf, float, distance>::VPTreeSearchResultElement> results;
-        tree->searchKNN(queries, k, results);
+        tree.searchKNN(queries, k, results);
 
         std::vector<std::vector<unsigned int>> indexes;
         std::vector<std::vector<float>> distances;
@@ -65,48 +51,35 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
 
     std::tuple<std::vector<unsigned int>, std::vector<float>> search1NN(const ndarrayf &queries) {
 
-        if (tree == nullptr) {
+        if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
 
         std::vector<unsigned int> indices;
         std::vector<float> distances;
-        tree->search1NN(queries, indices, distances);
+        tree.search1NN(queries, indices, distances);
 
         return std::make_tuple(std::move(indices), std::move(distances));
     }
 
-    vptree::VPTree<arrayf, float, distance> *tree = nullptr;
+    vptree::VPTree<arrayf, float, distance> tree;
 };
 
 class VPTreeBinaryNumpyAdapter {
     public:
-    VPTreeBinaryNumpyAdapter() { setEmpty(); }
+    VPTreeBinaryNumpyAdapter() = default; 
 
     void set(const ndarrayli &array) {
-        clear();
-        tree = new vptree::VPTree<arrayli, int64_t, dist_hamming>(array);
-    }
-
-    void setEmpty() {
-        clear();
-        tree = new vptree::VPTree<arrayli, int64_t, dist_hamming>();
-    }
-
-    void clear() {
-        if (tree != nullptr) {
-            delete tree;
-        }
-        tree = nullptr;
+        tree.set(array);
     }
 
     std::tuple<std::vector<std::vector<unsigned int>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
-        if (tree == nullptr) {
+        if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
 
         std::vector<vptree::VPTree<arrayli, int64_t, dist_hamming>::VPTreeSearchResultElement> results;
-        tree->searchKNN(queries, k, results);
+        tree.searchKNN(queries, k, results);
 
         std::vector<std::vector<unsigned int>> indexes;
         std::vector<std::vector<int64_t>> distances;
@@ -120,18 +93,18 @@ class VPTreeBinaryNumpyAdapter {
     }
 
     std::tuple<std::vector<unsigned int>, std::vector<int64_t>> search1NN(const ndarrayli &queries) {
-        if (tree == nullptr) {
+        if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
 
         std::vector<unsigned int> indices;
         std::vector<int64_t> distances;
-        tree->search1NN(queries, indices, distances);
+        tree.search1NN(queries, indices, distances);
 
         return std::make_tuple(std::move(indices), std::move(distances));
     }
 
-    vptree::VPTree<arrayli, int64_t, dist_hamming> *tree;
+    vptree::VPTree<arrayli, int64_t, dist_hamming> tree;
 };
 
 PYBIND11_MODULE(_pyvptree, m) {
@@ -143,7 +116,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeNumpyAdapter<dist_l2_f_avx2> &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree->serialize();
+                vptree::SerializedState state = p.tree.serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -153,7 +126,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeNumpyAdapter<dist_l2_f_avx2> p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree->deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));
@@ -166,7 +139,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeNumpyAdapter<dist_l1_f_avx2> &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree->serialize();
+                vptree::SerializedState state = p.tree.serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -176,7 +149,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeNumpyAdapter<dist_l1_f_avx2> p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree->deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));
@@ -189,7 +162,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeNumpyAdapter<dist_chebyshev_f_avx2> &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree->serialize();
+                vptree::SerializedState state = p.tree.serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -199,7 +172,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeNumpyAdapter<dist_chebyshev_f_avx2> p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree->deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));
@@ -212,7 +185,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeBinaryNumpyAdapter &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree->serialize();
+                vptree::SerializedState state = p.tree.serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -222,7 +195,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeBinaryNumpyAdapter p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree->deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -28,7 +28,7 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
         tree.set(array);
     }
 
-    std::tuple<std::vector<std::vector<unsigned int>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
+    std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
 
         if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
@@ -37,7 +37,7 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
         std::vector<typename vptree::VPTree<arrayf, float, distance>::VPTreeSearchResultElement> results;
         tree.searchKNN(queries, k, results);
 
-        std::vector<std::vector<unsigned int>> indexes;
+        std::vector<std::vector<int64_t>> indexes;
         std::vector<std::vector<float>> distances;
         indexes.resize(results.size());
         distances.resize(results.size());
@@ -49,13 +49,13 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
         return std::make_tuple(indexes, distances);
     }
 
-    std::tuple<std::vector<unsigned int>, std::vector<float>> search1NN(const ndarrayf &queries) {
+    std::tuple<std::vector<int64_t>, std::vector<float>> search1NN(const ndarrayf &queries) {
 
         if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
 
-        std::vector<unsigned int> indices;
+        std::vector<int64_t> indices;
         std::vector<float> distances;
         tree.search1NN(queries, indices, distances);
 
@@ -73,7 +73,7 @@ class VPTreeBinaryNumpyAdapter {
         tree.set(array);
     }
 
-    std::tuple<std::vector<std::vector<unsigned int>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
+    std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
         if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
@@ -81,7 +81,7 @@ class VPTreeBinaryNumpyAdapter {
         std::vector<vptree::VPTree<arrayli, int64_t, dist_hamming>::VPTreeSearchResultElement> results;
         tree.searchKNN(queries, k, results);
 
-        std::vector<std::vector<unsigned int>> indexes;
+        std::vector<std::vector<int64_t>> indexes;
         std::vector<std::vector<int64_t>> distances;
         indexes.resize(results.size());
         distances.resize(results.size());
@@ -92,12 +92,12 @@ class VPTreeBinaryNumpyAdapter {
         return std::make_tuple(indexes, distances);
     }
 
-    std::tuple<std::vector<unsigned int>, std::vector<int64_t>> search1NN(const ndarrayli &queries) {
+    std::tuple<std::vector<int64_t>, std::vector<int64_t>> search1NN(const ndarrayli &queries) {
         if (tree.isEmpty()) {
             throw std::runtime_error("indices must be first initialized with .set function");
         }
 
-        std::vector<unsigned int> indices;
+        std::vector<int64_t> indices;
         std::vector<int64_t> distances;
         tree.search1NN(queries, indices, distances);
 

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <omp.h>
+#include <stdexcept>
 
 #include <ISerializable.hpp>
 
@@ -21,14 +22,34 @@ typedef float (*distance_func_f)(const arrayf &, const arrayf &);
 
 template <distance_func_f distance> class VPTreeNumpyAdapter {
     public:
-    VPTreeNumpyAdapter() = default;
+    VPTreeNumpyAdapter() { setEmpty(); }
+    ~VPTreeNumpyAdapter() { clear(); }
 
-    void set(const ndarrayf &array) { tree = vptree::VPTree<arrayf, float, distance>(array); }
+    void set(const ndarrayf &array) {
+        clear();
+        tree = new vptree::VPTree<arrayf, float, distance>(array);
+    }
+
+    void setEmpty() {
+        clear();
+        tree = new vptree::VPTree<arrayf, float, distance>();
+    }
+
+    void clear() {
+        if (tree != nullptr) {
+            delete tree;
+        }
+        tree = nullptr;
+    }
 
     std::tuple<std::vector<std::vector<unsigned int>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
 
+        if (tree == nullptr) {
+            throw std::runtime_error("indices must be first initialized with .set function");
+        }
+
         std::vector<typename vptree::VPTree<arrayf, float, distance>::VPTreeSearchResultElement> results;
-        tree.searchKNN(queries, k, results);
+        tree->searchKNN(queries, k, results);
 
         std::vector<std::vector<unsigned int>> indexes;
         std::vector<std::vector<float>> distances;
@@ -44,26 +65,48 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
 
     std::tuple<std::vector<unsigned int>, std::vector<float>> search1NN(const ndarrayf &queries) {
 
+        if (tree == nullptr) {
+            throw std::runtime_error("indices must be first initialized with .set function");
+        }
+
         std::vector<unsigned int> indices;
         std::vector<float> distances;
-        tree.search1NN(queries, indices, distances);
+        tree->search1NN(queries, indices, distances);
 
         return std::make_tuple(std::move(indices), std::move(distances));
     }
 
-    vptree::VPTree<arrayf, float, distance> tree;
+    vptree::VPTree<arrayf, float, distance> *tree = nullptr;
 };
 
 class VPTreeBinaryNumpyAdapter {
     public:
-    VPTreeBinaryNumpyAdapter() = default;
+    VPTreeBinaryNumpyAdapter() { setEmpty(); }
 
-    void set(const ndarrayli &array) { tree = vptree::VPTree<arrayli, int64_t, dist_hamming>(array); }
+    void set(const ndarrayli &array) {
+        clear();
+        tree = new vptree::VPTree<arrayli, int64_t, dist_hamming>(array);
+    }
+
+    void setEmpty() {
+        clear();
+        tree = new vptree::VPTree<arrayli, int64_t, dist_hamming>();
+    }
+
+    void clear() {
+        if (tree != nullptr) {
+            delete tree;
+        }
+        tree = nullptr;
+    }
 
     std::tuple<std::vector<std::vector<unsigned int>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
+        if (tree == nullptr) {
+            throw std::runtime_error("indices must be first initialized with .set function");
+        }
 
         std::vector<vptree::VPTree<arrayli, int64_t, dist_hamming>::VPTreeSearchResultElement> results;
-        tree.searchKNN(queries, k, results);
+        tree->searchKNN(queries, k, results);
 
         std::vector<std::vector<unsigned int>> indexes;
         std::vector<std::vector<int64_t>> distances;
@@ -77,15 +120,18 @@ class VPTreeBinaryNumpyAdapter {
     }
 
     std::tuple<std::vector<unsigned int>, std::vector<int64_t>> search1NN(const ndarrayli &queries) {
+        if (tree == nullptr) {
+            throw std::runtime_error("indices must be first initialized with .set function");
+        }
 
         std::vector<unsigned int> indices;
         std::vector<int64_t> distances;
-        tree.search1NN(queries, indices, distances);
+        tree->search1NN(queries, indices, distances);
 
         return std::make_tuple(std::move(indices), std::move(distances));
     }
 
-    vptree::VPTree<arrayli, int64_t, dist_hamming> tree;
+    vptree::VPTree<arrayli, int64_t, dist_hamming> *tree;
 };
 
 PYBIND11_MODULE(_pyvptree, m) {
@@ -97,7 +143,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeNumpyAdapter<dist_l2_f_avx2> &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree.serialize();
+                vptree::SerializedState state = p.tree->serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -107,7 +153,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeNumpyAdapter<dist_l2_f_avx2> p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree->deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));
@@ -120,7 +166,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeNumpyAdapter<dist_l1_f_avx2> &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree.serialize();
+                vptree::SerializedState state = p.tree->serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -130,7 +176,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeNumpyAdapter<dist_l1_f_avx2> p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree->deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));
@@ -143,7 +189,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeNumpyAdapter<dist_chebyshev_f_avx2> &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree.serialize();
+                vptree::SerializedState state = p.tree->serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -153,7 +199,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeNumpyAdapter<dist_chebyshev_f_avx2> p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree->deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));
@@ -166,7 +212,7 @@ PYBIND11_MODULE(_pyvptree, m) {
         .def(py::pickle(
             [](const VPTreeBinaryNumpyAdapter &p) { // __getstate__
                 /* Return a tuple that fully encodes the state of the object */
-                vptree::SerializedState state = p.tree.serialize();
+                vptree::SerializedState state = p.tree->serialize();
                 py::tuple t = py::make_tuple(state.data, state.checksum);
 
                 return t;
@@ -176,7 +222,7 @@ PYBIND11_MODULE(_pyvptree, m) {
                 VPTreeBinaryNumpyAdapter p;
                 std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree->deserialize(vptree::SerializedState(data, checksum));
 
                 return p;
             }));

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -27,7 +27,7 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
 
     void set(const ndarrayf &array) { tree.set(array); }
 
-    std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
+    std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, size_t k) {
 
         std::vector<typename vptree::VPTree<arrayf, float, distance>::VPTreeSearchResultElement> results;
         tree.searchKNN(queries, k, results);
@@ -69,7 +69,7 @@ class VPTreeBinaryNumpyAdapter {
 
     void set(const ndarrayli &array) { tree.set(array); }
 
-    std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
+    std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, size_t k) {
 
         std::vector<vptree::VPTree<arrayli, int64_t, dist_hamming>::VPTreeSearchResultElement> results;
         tree.searchKNN(queries, k, results);

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -24,9 +24,7 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
     public:
     VPTreeNumpyAdapter() = default;
 
-    void set(const ndarrayf &array) {
-        tree.set(array);
-    }
+    void set(const ndarrayf &array) { tree.set(array); }
 
     std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
 
@@ -67,11 +65,9 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
 
 class VPTreeBinaryNumpyAdapter {
     public:
-    VPTreeBinaryNumpyAdapter() = default; 
+    VPTreeBinaryNumpyAdapter() = default;
 
-    void set(const ndarrayli &array) {
-        tree.set(array);
-    }
+    void set(const ndarrayli &array) { tree.set(array); }
 
     std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
         if (tree.isEmpty()) {
@@ -124,9 +120,9 @@ PYBIND11_MODULE(_pyvptree, m) {
             [](py::tuple t) { // __setstate__
                 /* Create a new C++ instance */
                 VPTreeNumpyAdapter<dist_l2_f_avx2> p;
-                std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
+                std::vector<uint8_t> state = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(state, checksum));
 
                 return p;
             }));
@@ -147,9 +143,9 @@ PYBIND11_MODULE(_pyvptree, m) {
             [](py::tuple t) { // __setstate__
                 /* Create a new C++ instance */
                 VPTreeNumpyAdapter<dist_l1_f_avx2> p;
-                std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
+                std::vector<uint8_t> state = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(state, checksum));
 
                 return p;
             }));
@@ -170,9 +166,9 @@ PYBIND11_MODULE(_pyvptree, m) {
             [](py::tuple t) { // __setstate__
                 /* Create a new C++ instance */
                 VPTreeNumpyAdapter<dist_chebyshev_f_avx2> p;
-                std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
+                std::vector<uint8_t> state = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(state, checksum));
 
                 return p;
             }));
@@ -193,9 +189,9 @@ PYBIND11_MODULE(_pyvptree, m) {
             [](py::tuple t) { // __setstate__
                 /* Create a new C++ instance */
                 VPTreeBinaryNumpyAdapter p;
-                std::vector<uint8_t> data = t[0].cast<std::vector<uint8_t>>();
+                std::vector<uint8_t> state = t[0].cast<std::vector<uint8_t>>();
                 uint8_t checksum = t[1].cast<uint8_t>();
-                p.tree.deserialize(vptree::SerializedState(data, checksum));
+                p.tree.deserialize(vptree::SerializedState(state, checksum));
 
                 return p;
             }));

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -29,10 +29,6 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
 
     std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<float>>> searchKNN(const ndarrayf &queries, unsigned int k) {
 
-        if (tree.isEmpty()) {
-            throw std::runtime_error("indices must be first initialized with .set function");
-        }
-
         std::vector<typename vptree::VPTree<arrayf, float, distance>::VPTreeSearchResultElement> results;
         tree.searchKNN(queries, k, results);
 
@@ -49,10 +45,6 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
     }
 
     std::tuple<std::vector<int64_t>, std::vector<float>> search1NN(const ndarrayf &queries) {
-
-        if (tree.isEmpty()) {
-            throw std::runtime_error("indices must be first initialized with .set function");
-        }
 
         std::vector<int64_t> indices;
         std::vector<float> distances;
@@ -78,9 +70,6 @@ class VPTreeBinaryNumpyAdapter {
     void set(const ndarrayli &array) { tree.set(array); }
 
     std::tuple<std::vector<std::vector<int64_t>>, std::vector<std::vector<int64_t>>> searchKNN(const ndarrayli &queries, unsigned int k) {
-        if (tree.isEmpty()) {
-            throw std::runtime_error("indices must be first initialized with .set function");
-        }
 
         std::vector<vptree::VPTree<arrayli, int64_t, dist_hamming>::VPTreeSearchResultElement> results;
         tree.searchKNN(queries, k, results);
@@ -97,9 +86,6 @@ class VPTreeBinaryNumpyAdapter {
     }
 
     std::tuple<std::vector<int64_t>, std::vector<int64_t>> search1NN(const ndarrayli &queries) {
-        if (tree.isEmpty()) {
-            throw std::runtime_error("indices must be first initialized with .set function");
-        }
 
         std::vector<int64_t> indices;
         std::vector<int64_t> distances;

--- a/pyvptree/src/PythonBindings.cpp
+++ b/pyvptree/src/PythonBindings.cpp
@@ -3,18 +3,19 @@
  *  Copyright 2021 Pablo Carneiro Elias
  */
 
-#include <DistanceFunctions.hpp>
-#include <VPTree.hpp>
-#include <iostream>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <cassert>
+#include <iostream>
 #include <omp.h>
+#include <sstream>
 #include <stdexcept>
 
+#include <DistanceFunctions.hpp>
 #include <ISerializable.hpp>
+#include <VPTree.hpp>
 
 namespace py = pybind11;
 
@@ -60,6 +61,13 @@ template <distance_func_f distance> class VPTreeNumpyAdapter {
         return std::make_tuple(std::move(indices), std::move(distances));
     }
 
+    std::string to_string() {
+        std::stringstream stream;
+        stream << tree;
+
+        return stream.str();
+    }
+
     vptree::VPTree<arrayf, float, distance> tree;
 };
 
@@ -100,6 +108,13 @@ class VPTreeBinaryNumpyAdapter {
         return std::make_tuple(std::move(indices), std::move(distances));
     }
 
+    std::string to_string() {
+        std::stringstream stream;
+        stream << tree;
+
+        return stream.str();
+    }
+
     vptree::VPTree<arrayli, int64_t, dist_hamming> tree;
 };
 
@@ -107,6 +122,7 @@ PYBIND11_MODULE(_pyvptree, m) {
     py::class_<VPTreeNumpyAdapter<dist_l2_f_avx2>>(m, "VPTreeL2Index")
         .def(py::init<>())
         .def("set", &VPTreeNumpyAdapter<dist_l2_f_avx2>::set)
+        .def("to_string", &VPTreeNumpyAdapter<dist_l2_f_avx2>::to_string)
         .def("searchKNN", &VPTreeNumpyAdapter<dist_l2_f_avx2>::searchKNN)
         .def("search1NN", &VPTreeNumpyAdapter<dist_l2_f_avx2>::search1NN)
         .def(py::pickle(
@@ -130,6 +146,7 @@ PYBIND11_MODULE(_pyvptree, m) {
     py::class_<VPTreeNumpyAdapter<dist_l1_f_avx2>>(m, "VPTreeL1Index")
         .def(py::init<>())
         .def("set", &VPTreeNumpyAdapter<dist_l1_f_avx2>::set)
+        .def("to_string", &VPTreeNumpyAdapter<dist_l1_f_avx2>::to_string)
         .def("searchKNN", &VPTreeNumpyAdapter<dist_l1_f_avx2>::searchKNN)
         .def("search1NN", &VPTreeNumpyAdapter<dist_l1_f_avx2>::search1NN)
         .def(py::pickle(
@@ -153,6 +170,7 @@ PYBIND11_MODULE(_pyvptree, m) {
     py::class_<VPTreeNumpyAdapter<dist_chebyshev_f_avx2>>(m, "VPTreeChebyshevIndex")
         .def(py::init<>())
         .def("set", &VPTreeNumpyAdapter<dist_chebyshev_f_avx2>::set)
+        .def("to_string", &VPTreeNumpyAdapter<dist_chebyshev_f_avx2>::to_string)
         .def("searchKNN", &VPTreeNumpyAdapter<dist_chebyshev_f_avx2>::searchKNN)
         .def("search1NN", &VPTreeNumpyAdapter<dist_chebyshev_f_avx2>::search1NN)
         .def(py::pickle(
@@ -176,6 +194,7 @@ PYBIND11_MODULE(_pyvptree, m) {
     py::class_<VPTreeBinaryNumpyAdapter>(m, "VPTreeBinaryIndex")
         .def(py::init<>())
         .def("set", &VPTreeBinaryNumpyAdapter::set)
+        .def("to_string", &VPTreeBinaryNumpyAdapter::to_string)
         .def("searchKNN", &VPTreeBinaryNumpyAdapter::searchKNN)
         .def("search1NN", &VPTreeBinaryNumpyAdapter::search1NN)
         .def(py::pickle(

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <iostream>
 #include <random>
+#include <sstream>
 #include <vector>
 
 #include <stdint.h>
@@ -119,6 +120,26 @@ TEST(VPTests, TestEmpty) {
 
     EXPECT_EQ(indices.size(), indices2.size());
     EXPECT_EQ(indices.size(), 0);
+}
+
+TEST(VPTests, TestToString) {
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution(-10, 10);
+
+    const unsigned int numPoints = 14001;
+    std::vector<Eigen::Vector3d> points;
+    points.reserve(numPoints);
+    points.resize(numPoints);
+    for (Eigen::Vector3d &point : points) {
+        point[0] = distribution(generator);
+        point[1] = distribution(generator);
+        point[2] = distribution(generator);
+    }
+
+    VPTree<Eigen::Vector3d, float, distance> tree(points);
+
+    std::stringstream ss;
+    ss << tree;
 }
 
 TEST(VPTests, TestCopy) {

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -162,7 +162,6 @@ TEST(VPTests, TestCopy) {
     }
 }
 
-
 TEST(VPTests, TestSerialization) {
 
     std::default_random_engine generator;

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -95,6 +95,32 @@ TEST(VPTests, TestHamming) {
     EXPECT_EQ(dist_hamming(b17, b27), 256);
 }
 
+TEST(VPTests, TestEmpty) {
+    VPTree<Eigen::Vector3d, float, distance> tree2;
+    VPTree<Eigen::Vector3d, float, distance> tree;
+
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution(-10, 10);
+
+    std::vector<Eigen::Vector3d> queries;
+    queries.resize(100);
+    for (Eigen::Vector3d &point : queries) {
+        point[0] = distribution(generator);
+        point[1] = distribution(generator);
+        point[2] = distribution(generator);
+    }
+
+    std::vector<int64_t> indices;
+    std::vector<float> distances;
+    std::vector<int64_t> indices2;
+    std::vector<float> distances2;
+    tree.search1NN(queries, indices, distances);
+    tree2.search1NN(queries, indices2, distances2);
+
+    EXPECT_EQ(indices.size(), indices2.size());
+    EXPECT_EQ(indices.size(), 0);
+}
+
 TEST(VPTests, TestCopy) {
     std::default_random_engine generator;
     std::uniform_real_distribution<float> distribution(-10, 10);

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -100,7 +100,7 @@ TEST(VPTests, TestSerialization) {
     std::default_random_engine generator;
     std::uniform_real_distribution<float> distribution(-10, 10);
 
-    const unsigned int numPoints = 10000;
+    const unsigned int numPoints = 14001;
     std::vector<Eigen::Vector3d> points;
     points.reserve(numPoints);
     points.resize(numPoints);
@@ -113,7 +113,6 @@ TEST(VPTests, TestSerialization) {
     VPTree<Eigen::Vector3d, float, distance> tree2;
     VPTree<Eigen::Vector3d, float, distance> tree(points);
     auto state = tree.serialize();
-
     tree2.deserialize(state);
 
     std::vector<Eigen::Vector3d> queries;
@@ -123,7 +122,7 @@ TEST(VPTests, TestSerialization) {
         point[1] = distribution(generator);
         point[2] = distribution(generator);
     }
-    /* std::vector<VPTree<Eigen::Vector3d, float, distance>::VPTreeSearchResultElement> results; */
+
     std::vector<int64_t> indices;
     std::vector<float> distances;
     std::vector<int64_t> indices2;
@@ -133,12 +132,10 @@ TEST(VPTests, TestSerialization) {
 
     EXPECT_EQ(indices.size(), indices2.size());
     for (int i = 0; i < indices.size(); ++i) {
-      EXPECT_EQ(indices[i], indices2[i]) << "Vectors x and y differ at index " << i;
-      EXPECT_EQ(distances[i], distances2[i]) << "Vectors x and y differ at distance " << i;
+        EXPECT_EQ(indices[i], indices2[i]) << "Vectors x and y differ at index " << i;
+        EXPECT_EQ(distances[i], distances2[i]) << "Vectors x and y differ at distance " << i;
     }
-
 }
-
 
 TEST(VPTests, TestCreation) {
 
@@ -163,13 +160,10 @@ TEST(VPTests, TestCreation) {
 }
 
 TEST(VPTests, TestSearch) {
-
-    return;
-
     std::default_random_engine generator;
     std::uniform_real_distribution<float> distribution(-10, 10);
 
-    const unsigned int numPoints = 4e8;
+    const unsigned int numPoints = 4e4;
     std::vector<Eigen::Vector3d> points;
     points.resize(numPoints);
     for (Eigen::Vector3d &point : points) {
@@ -178,15 +172,10 @@ TEST(VPTests, TestSearch) {
         point[2] = distribution(generator);
     }
 
-    std::cout << "Building tree with " << numPoints << " points " << std::endl;
     auto start = std::chrono::steady_clock::now();
-
     VPTree<Eigen::Vector3d, float, distance> tree(points);
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<float> diff = end - start;
-    std::cout << "Process took " << diff.count() << " seconds " << std::endl;
-
-    std::cout << "Searching within the tree with " << numPoints << " points " << std::endl;
 
     std::vector<Eigen::Vector3d> queries;
     queries.resize(5000);
@@ -202,6 +191,5 @@ TEST(VPTests, TestSearch) {
     tree.search1NN(queries, indices, distances);
     end = std::chrono::steady_clock::now();
     diff = end - start;
-    std::cout << "Process took " << diff.count() << " seconds " << std::endl;
 }
 } // namespace vptree::tests

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -95,6 +95,48 @@ TEST(VPTests, TestHamming) {
     EXPECT_EQ(dist_hamming(b17, b27), 256);
 }
 
+TEST(VPTests, TestCopy) {
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution(-10, 10);
+
+    const unsigned int numPoints = 14001;
+    std::vector<Eigen::Vector3d> points;
+    points.reserve(numPoints);
+    points.resize(numPoints);
+    for (Eigen::Vector3d &point : points) {
+        point[0] = distribution(generator);
+        point[1] = distribution(generator);
+        point[2] = distribution(generator);
+    }
+
+    VPTree<Eigen::Vector3d, float, distance> tree2;
+    VPTree<Eigen::Vector3d, float, distance> tree(points);
+
+    tree2 = tree;
+
+    std::vector<Eigen::Vector3d> queries;
+    queries.resize(100);
+    for (Eigen::Vector3d &point : queries) {
+        point[0] = distribution(generator);
+        point[1] = distribution(generator);
+        point[2] = distribution(generator);
+    }
+
+    std::vector<int64_t> indices;
+    std::vector<float> distances;
+    std::vector<int64_t> indices2;
+    std::vector<float> distances2;
+    tree.search1NN(queries, indices, distances);
+    tree2.search1NN(queries, indices2, distances2);
+
+    EXPECT_EQ(indices.size(), indices2.size());
+    for (int i = 0; i < indices.size(); ++i) {
+        EXPECT_EQ(indices[i], indices2[i]) << "Vectors x and y differ at index " << i;
+        EXPECT_EQ(distances[i], distances2[i]) << "Vectors x and y differ at distance " << i;
+    }
+}
+
+
 TEST(VPTests, TestSerialization) {
 
     std::default_random_engine generator;

--- a/pyvptree/tests/VPTreeTests.cpp
+++ b/pyvptree/tests/VPTreeTests.cpp
@@ -95,6 +95,51 @@ TEST(VPTests, TestHamming) {
     EXPECT_EQ(dist_hamming(b17, b27), 256);
 }
 
+TEST(VPTests, TestSerialization) {
+
+    std::default_random_engine generator;
+    std::uniform_real_distribution<float> distribution(-10, 10);
+
+    const unsigned int numPoints = 10000;
+    std::vector<Eigen::Vector3d> points;
+    points.reserve(numPoints);
+    points.resize(numPoints);
+    for (Eigen::Vector3d &point : points) {
+        point[0] = distribution(generator);
+        point[1] = distribution(generator);
+        point[2] = distribution(generator);
+    }
+
+    VPTree<Eigen::Vector3d, float, distance> tree2;
+    VPTree<Eigen::Vector3d, float, distance> tree(points);
+    auto state = tree.serialize();
+
+    tree2.deserialize(state);
+
+    std::vector<Eigen::Vector3d> queries;
+    queries.resize(100);
+    for (Eigen::Vector3d &point : queries) {
+        point[0] = distribution(generator);
+        point[1] = distribution(generator);
+        point[2] = distribution(generator);
+    }
+    /* std::vector<VPTree<Eigen::Vector3d, float, distance>::VPTreeSearchResultElement> results; */
+    std::vector<int64_t> indices;
+    std::vector<float> distances;
+    std::vector<int64_t> indices2;
+    std::vector<float> distances2;
+    tree.search1NN(queries, indices, distances);
+    tree2.search1NN(queries, indices2, distances2);
+
+    EXPECT_EQ(indices.size(), indices2.size());
+    for (int i = 0; i < indices.size(); ++i) {
+      EXPECT_EQ(indices[i], indices2[i]) << "Vectors x and y differ at index " << i;
+      EXPECT_EQ(distances[i], distances2[i]) << "Vectors x and y differ at distance " << i;
+    }
+
+}
+
+
 TEST(VPTests, TestCreation) {
 
     std::default_random_engine generator;
@@ -120,6 +165,7 @@ TEST(VPTests, TestCreation) {
 TEST(VPTests, TestSearch) {
 
     return;
+
     std::default_random_engine generator;
     std::uniform_real_distribution<float> distribution(-10, 10);
 
@@ -150,7 +196,7 @@ TEST(VPTests, TestSearch) {
         point[2] = distribution(generator);
     }
     /* std::vector<VPTree<Eigen::Vector3d, float, distance>::VPTreeSearchResultElement> results; */
-    std::vector<unsigned int> indices;
+    std::vector<int64_t> indices;
     std::vector<float> distances;
     start = std::chrono::steady_clock::now();
     tree.search1NN(queries, indices, distances);

--- a/pyvptree/tests/test_serialization.py
+++ b/pyvptree/tests/test_serialization.py
@@ -65,3 +65,6 @@ def test_binary_serialization():
 
     vptree_indices_rec, vptree_distances_rec = recovered.search1NN(queries)
     assert vptree_distances_rec == vptree_distances
+
+
+test_basic_serialization()

--- a/pyvptree/tests/test_serialization.py
+++ b/pyvptree/tests/test_serialization.py
@@ -10,12 +10,21 @@ def test_empty_index_serialization():
     data_rec = pickle.dumps(recovered)
     assert data_rec == data
 
-    vptree = pyvptree.VPTreeBinaryIndex()
+    # not initializing data with .set() should
+    # be equivalent of initializing with empty array
+    vptree = pyvptree.VPTreeL2Index()
+    empty = np.array([]).reshape(-1,8)
+    vptree.set(empty)
     data = pickle.dumps(vptree)
     recovered = pickle.loads(data)
     data_rec = pickle.dumps(recovered)
     assert data_rec == data
 
+    vptree = pyvptree.VPTreeBinaryIndex()
+    data = pickle.dumps(vptree)
+    recovered = pickle.loads(data)
+    data_rec = pickle.dumps(recovered)
+    assert data_rec == data
 
 def test_basic_serialization():
     np.random.seed(seed=42)
@@ -41,6 +50,24 @@ def test_basic_serialization():
     vptree_indices_rec, vptree_distances_rec = recovered.search1NN(queries)
     assert vptree_indices_rec == vptree_indices and vptree_distances_rec == vptree_distances
 
+def test_string_serialization():
+    np.random.seed(seed=42)
+
+    num_points = 27
+    dimension = 8
+    data = np.random.rand(num_points, dimension).astype(dtype=np.float32)
+
+    vptree = pyvptree.VPTreeL2Index()
+    vptree.set(data)
+
+    string_state = vptree.to_string()
+
+    binary_state = pickle.dumps(vptree)
+    restored = pickle.loads(binary_state)
+
+    restored_string_state = restored.to_string()
+
+    assert restored_string_state == string_state
 
 def test_binary_serialization():
     np.random.seed(seed=42)

--- a/pyvptree/tests/test_vptree.py
+++ b/pyvptree/tests/test_vptree.py
@@ -37,6 +37,7 @@ def test_empty_index():
     try:
         vptree = pyvptree.VPTreeBinaryIndex()
         i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
+        assert i == [] and d == []
         # expect exception and should now reach this line
         # since index is empty, we should not be able to search
         assert False
@@ -46,6 +47,7 @@ def test_empty_index():
     try:
         vptree = pyvptree.VPTreeL2Index()
         i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
+        assert i == [] and d == []
         # expect exception and should now reach this line
         # since index is empty, we should not be able to search
         assert False

--- a/pyvptree/tests/test_vptree.py
+++ b/pyvptree/tests/test_vptree.py
@@ -33,6 +33,26 @@ def chebyshev_distance_pairwise(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     return np.max(np.abs(diff), axis=-1)
 
 
+def test_empty_index():
+    try:
+        vptree = pyvptree.VPTreeBinaryIndex()
+        i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
+        # expect exception and should now reach this line
+        # since index is empty, we should not be able to search
+        assert False
+    except Exception:
+        pass
+
+    try:
+        vptree = pyvptree.VPTreeL2Index()
+        i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
+        # expect exception and should now reach this line
+        # since index is empty, we should not be able to search
+        assert False
+    except Exception:
+        pass
+
+
 def test_hamming():
 
     def hamming_distance(a, b) -> np.ndarray:

--- a/pyvptree/tests/test_vptree.py
+++ b/pyvptree/tests/test_vptree.py
@@ -37,7 +37,6 @@ def test_empty_index():
     try:
         vptree = pyvptree.VPTreeBinaryIndex()
         i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
-        assert i == [] and d == []
         # expect exception and should now reach this line
         # since index is empty, we should not be able to search
         assert False
@@ -47,10 +46,21 @@ def test_empty_index():
     try:
         vptree = pyvptree.VPTreeL2Index()
         i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
-        assert i == [] and d == []
         # expect exception and should now reach this line
         # since index is empty, we should not be able to search
         assert False
+    except Exception:
+        pass
+
+    try:
+        vptree = pyvptree.VPTreeL2Index()
+        empty = np.array([]).reshape(-1,2)
+        vptree.set(empty)
+        i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
+        assert False
+
+        # expect no exception and should now reach this line
+        # since index is empty, we should not be able to search
     except Exception:
         pass
 


### PR DESCRIPTION
Fixes a sever bug that vptree was not correctly implementing copy and assignment operator
as well was not properly destroying allocated memory.
This was preventing several other functionalities from working correctly.

This PR includes:
- Refactored serialization code
- Fixed memory allocation issues
- Created proper copy/assignment constructors
- Added several more tests
- Extinguished use of unsigned int for indices (now only use int64_t)
- Split VPTree into VPTreePartition and VPTree files

It also includes a new string stream serialization to visualize the tree:
In Python:

```python
print(vptree.to_string())
```
Output:
``` 
####################
# [VPTree state]
Num Data Points: 100
Total Memory: 8000 bytes
####################
[+] Root Level:
 Depth: 0
 Height: 14
 Num Sub Nodes: 100
 Index Start: 0
 Index End:   99
 Left Subtree Height: 12
 Right Subtree Height: 12
 [+] Left children:
.... Depth: 1
.... Height: 12
.... Num Sub Nodes: 49
.... Index Start: 1
.... Index End:   49
.... Left Subtree Height: 10
.... Right Subtree Height: 10
.... [+] Left children:
........ Depth: 2
........ Height: 10
........ Num Sub Nodes: 24
........ Index Start: 2
........ Index End:   25
........ Left Subtree Height: 8
........ Right Subtree Height: 8
........ [+] Left children:
............ Depth: 3
............ Height: 8
............ Num Sub Nodes: 11
............ Index Start: 3
............ Index End:   13
............ Left Subtree Height: 6
............ Right Subtree Height: 6
............ [+] Left children:
```

This allows debugging tree internal state as well as checking total memory footprint and tree balance state.

In C++:
```cpp
std::cout << vptree;
```