### PR TITLE
Docs/update readme, formatter and formating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 init-repo:
 ifeq (, $(shell which clang-format))
 	@echo "Installing formatting tools ..."
-	@pip install isort black
+	@pip install isort black flake8
 ifeq ($(UNAME_S),Linux)
 	sudo apt install clang-format
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: init-repo
 init-repo:
 ifeq (, $(shell which clang-format))
-	@echo "Installing stylize ..."
-	@pip install stylize
+	@echo "Installing formatting tools ..."
+	@pip install isort black
 ifeq ($(UNAME_S),Linux)
 	sudo apt install clang-format
 endif
@@ -17,11 +17,10 @@ endif
 
 .PHONY: fmt
 fmt: init-repo
-	stylize --exclude_dirs=pynear/include/Eigen --yapf_style="{based_on_style: google, column_limit: 150, indent_width: 4}"
-
-.PHONY: check-fmt
-check-fmt:
-	stylize --check --exclude_dirs=pynear/include/Eigen --yapf_style="{based_on_style: google, column_limit: 150, indent_width: 4}"
+	clang-format -i --verbose pynear/src/*.cpp pynear/include/*.hpp
+	isort --sl --fss -j 0 .
+	flake8
+	black .
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -2,29 +2,7 @@
 
 PyNear is a python library, internally built in C++, for efficient KNN search using metric distance function such as L2 distance (see VPTreeL2Index) or Hamming distances (VPTreeBinaryIndex) as well as other indices. It uses AVX2 instructions to optimize distance functions so to improve search performance.
 
-## How VP-Trees work
-
-VP-Trees are binary trees that successively divide spaces in order to perform different types of tasks, such as Nearest Neighbor Search. It differs from Kd-Trees in the sense that they always partition the whole space, instead of individual dimensional axes, using a specific metric function and a selected "Vantage Point" that will be used as reference to allow splitting the dataset. For more details on how it works please access the following references:
-
-- https://en.wikipedia.org/wiki/Vantage-point_tree
-- https://fribbels.github.io/vptree/writeup
-- [Probabilistic analysis of vantage point trees](https://www.vmsta.org/journal/VMSTA/article/219/file/pdf)
-
-### Theoretical advantage of Vantage Points Trees compared to Kd-Trees
-
-- Intrinsic Dimensionality: VP-trees perform well in data with high intrinsic dimensionality, where the effective dimensionality is high. In contrast, kd-trees are efficient in low-dimensional spaces but their performance degrades quickly as the number of dimensions increases. This is often referred to as the "curse of dimensionality".
-
-- No Assumption about Axis-Alignment: Unlike kd-trees, which make a specific assumption about axis-alignment, VP-trees do not make such assumptions. This makes VP-trees potentially more robust to different kinds of data, especially when there is no natural way to align the axes with respect to the data.
-
-- Metric Spaces: VP-trees can handle general metric spaces (any space where a distance function is defined that satisfies the triangle inequality), not just Euclidean spaces. This makes them more adaptable to different problem settings where the distance metric might not be the standard Euclidean distance.
-
-- Handling Categorical Data: VP-trees, due to their use of arbitrary distance functions, can handle categorical data more naturally than kd-trees. While there are workarounds to use kd-trees with categorical data, they often require substantial tweaking and may not perform optimally. For categorical data, another reference structure is the [BK-Tree](https://en.wikipedia.org/wiki/BK-tree), which is very efficient when comes to low dimensional data.
-
-- Balanced Tree Structure: VP-trees inherently try to create a balanced tree structure, which is beneficial for efficient searching. kd-trees can become unbalanced in certain situations, particularly with non-uniform data, leading to inefficient search operations.
-
-It's important to notice, however, that practical implementation approaches such as using [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) instructions or using highly optimized distance functions can strongly affect final performance in high dimensions. For instance, [Faiss Library](https://github.com/facebookresearch/faiss) performs very efficiently in very high dimensions, where searches become near linear and exaustive, due to highly optimized code.
-
-Typically spatial search structures tend to perform worse with increasing number of dimensions of dataset.
+PyNear aims providing different efficient algorithms for nearest neighbor search. One of the differentials of PyNear is the adoption of [Vantage Point Tree](./docs/vptrees.md) in order to mitigate course of dimensionality for high dimensional features (see VPTree* indices for more information in [docs](./docs/README.md)).
 
 
 # Installation

--- a/docs/vptrees.md
+++ b/docs/vptrees.md
@@ -1,0 +1,24 @@
+## How Vantage Point Trees work
+
+VP-Trees are binary trees that successively divide spaces in order to perform different types of tasks, such as Nearest Neighbor Search. It differs from kd-Trees in the sense that they always partition the whole space, instead of individual dimensional axes, using a specific metric function and a selected "Vantage Point" that will be used as reference to allow splitting the dataset. For more details on how it works please access the following references:
+
+- https://en.wikipedia.org/wiki/Vantage-point_tree
+- https://fribbels.github.io/vptree/writeup
+- [Probabilistic analysis of vantage point trees](https://www.vmsta.org/journal/VMSTA/article/219/file/pdf)
+
+### Theoretical advantage of Vantage Points Trees compared to Kd-Trees
+
+- Intrinsic Dimensionality: VP-trees perform well in data with high intrinsic dimensionality, where the effective dimensionality is high. In contrast, kd-trees are efficient in low-dimensional spaces but their performance degrades quickly as the number of dimensions increases. This is often referred to as the "curse of dimensionality".
+
+- No Assumption about Axis-Alignment: Unlike kd-trees, which make a specific assumption about axis-alignment, VP-trees do not make such assumptions. This makes VP-trees potentially more robust to different kinds of data, especially when there is no natural way to align the axes with respect to the data.
+
+- Metric Spaces: VP-trees can handle general metric spaces (any space where a distance function is defined that satisfies the triangle inequality), not just Euclidean spaces. This makes them more adaptable to different problem settings where the distance metric might not be the standard Euclidean distance.
+
+- Handling Categorical Data: VP-trees, due to their use of arbitrary distance functions, can handle categorical data more naturally than kd-trees. While there are workarounds to use kd-trees with categorical data, they often require substantial tweaking and may not perform optimally. For categorical data, another reference structure is the [BK-Tree](https://en.wikipedia.org/wiki/BK-tree), which is very efficient when comes to low dimensional data.
+
+- Balanced Tree Structure: VP-trees inherently try to create a balanced tree structure, which is beneficial for efficient searching. kd-trees can become unbalanced in certain situations, particularly with non-uniform data, leading to inefficient search operations.
+
+Different mplementation approaches such as using [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) and [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) instructions affect final performance in high dimensions. For instance, [Faiss Library](https://github.com/facebookresearch/faiss) performs very efficiently in very high dimensions, where searches become near linear and exhaustive, due to highly optimized code.
+ 
+PyNear adopts AVX2 instructions to optimize some of the indices such as VPTreeL2Index and VPTreeBinaryIndex.
+

--- a/pynear/__init__.py
+++ b/pynear/__init__.py
@@ -1,8 +1,8 @@
-from typing import Type
-from _pynear import VPTreeBinaryIndex512
-from _pynear import VPTreeBinaryIndex256
-from _pynear import VPTreeBinaryIndex128
+# flake8: noqa
 from _pynear import VPTreeBinaryIndex64
+from _pynear import VPTreeBinaryIndex128
+from _pynear import VPTreeBinaryIndex256
+from _pynear import VPTreeBinaryIndex512
 from _pynear import VPTreeChebyshevIndex
 from _pynear import VPTreeL1Index
 from _pynear import VPTreeL2Index
@@ -11,7 +11,6 @@ from ._version import __version__
 
 
 class VPTreeBinaryIndex:
-
     def __init__(self):
         self._index = None
         self._dimension = None
@@ -38,7 +37,9 @@ class VPTreeBinaryIndex:
 
         dim = queries.shape[1]
         if dim != self._dimension:
-            raise ValueError(f"invalid data dimension: index built data and query data dimensions must agree, index built data dimension is {dim}")
+            raise ValueError(
+                f"invalid data dimension: index built data and query data dimensions must agree, index built data dimension is {dim}"
+            )
 
         self._validate(queries)
         return self._index.searchKNN(queries, k)
@@ -54,7 +55,7 @@ class VPTreeBinaryIndex:
         if len(input.shape) != 2:
             raise ValueError("invalid data shape: binary indexes must be 2D")
 
-        if input.dtype != 'uint8':
+        if input.dtype != "uint8":
             raise TypeError("invalid data type: binary indexes must be uint8")
 
         dim = input.shape[1]

--- a/pynear/benchmark/__init__.py
+++ b/pynear/benchmark/__init__.py
@@ -1,2 +1,4 @@
-from pynear.benchmark.benchmark import BenchmarkRunner
+# flake8: noqa
+
 from pynear.benchmark.benchmark import BenchmarkCase
+from pynear.benchmark.benchmark import BenchmarkRunner

--- a/pynear/benchmark/benchmark.py
+++ b/pynear/benchmark/benchmark.py
@@ -1,15 +1,16 @@
-import time
-import yaml
+from dataclasses import dataclass
+from typing import Any
+from typing import Dict
+from typing import Generator
+from typing import List
+
 import numpy as np
 import pandas as pd
-import faiss
-import pynear
-from sklearn.neighbors import NearestNeighbors
-from typing import Callable, Any, Dict, Generator, List, Optional, Tuple, Union
-from dataclasses import dataclass
+import yaml
+
 from pynear.benchmark.dataset import generate_gaussian_dataset
-from pynear.logging import create_and_configure_log
 from pynear.benchmark.index_adapters import create_index_adapter
+from pynear.logging import create_and_configure_log
 
 logger = create_and_configure_log(__name__)
 
@@ -46,14 +47,14 @@ class BenchmarkCase:
                 dimension,
                 data_type=np.dtype(self.dataset_type),
             )
-            logger.info(f"generating dataset done")
+            logger.info("generating dataset done")
             for k_value in self.k:
                 for index_type in self.index_types:
                     logger.info(f"processing index_type: {index_type} for k = {k_value} and dimension = {dimension}")
                     index = create_index_adapter(index_type)
-                    logger.info(f"buiding index ...")
+                    logger.info("buiding index ...")
                     index.build_index(data)
-                    logger.info(f"buiding index done")
+                    logger.info("buiding index done")
                     logger.info("start performing queries")
                     for num_queries in self.num_queries:
                         query = generate_gaussian_dataset(
@@ -72,18 +73,20 @@ class BenchmarkCase:
                         avg = sum(runs) / len(runs)
                         logger.info(f"avg of {NUM_AVG_SEARCHS} searches runtime is {avg:0.4f}")
 
-                        results.append({
-                            "time": avg,
-                            "k": k_value,
-                            "num_seraches_avg": NUM_AVG_SEARCHS,
-                            "num_queries": num_queries,
-                            "index_type": index_type,
-                            "dimension": dimension,
-                            "dataset_total_size": self.dataset_total_size,
-                            "dataset_num_clusters": self.dataset_num_clusters,
-                        })
+                        results.append(
+                            {
+                                "time": avg,
+                                "k": k_value,
+                                "num_seraches_avg": NUM_AVG_SEARCHS,
+                                "num_queries": num_queries,
+                                "index_type": index_type,
+                                "dimension": dimension,
+                                "dataset_total_size": self.dataset_total_size,
+                                "dataset_num_clusters": self.dataset_num_clusters,
+                            }
+                        )
                         logger.info(f"done performing queries for (num_queries = {num_queries})")
-                    logger.info(f"queries done")
+                    logger.info("queries done")
         return {"benchmark_case_id": self.id(), "benchmark_case_name": self.name, "results": results}
 
     # the random seed for reproducibility
@@ -99,6 +102,7 @@ class BenchmarkCase:
     @staticmethod
     def reject_outliers(data, m=1.2):
         return data[abs(data - np.mean(data)) < m * np.std(data)]
+
 
 class BenchmarkRunner:
     """

--- a/pynear/benchmark/dataset.py
+++ b/pynear/benchmark/dataset.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 import numpy as np
 
 

--- a/pynear/benchmark/index_adapters.py
+++ b/pynear/benchmark/index_adapters.py
@@ -1,30 +1,33 @@
+from abc import ABC
+from abc import abstractmethod
 import time
+
 import annoy
 import faiss
-import pynear
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
-from abc import ABC, abstractmethod
+
+import pynear
 
 
 def create_index_adapter(index_name: str):
     # Supported 3rd party indices are: FaissIndexFlatL2, FaissIndexBinaryFlat, AnnoyL2, AnnoyManhattan, AnnoyHamming, SKLearnL2
     mapper = {
-        'FaissIndexFlatL2': FaissIndexFlatL2Adapter,
-        'FaissIndexBinaryFlat': FaissIndexBinaryFlatAdapter,
-        'AnnoyL2': AnnoyL2Adapter,
-        'AnnoyManhattan': AnnoyManhattanAdapter,
-        'AnnoyHamming': AnnoyHammingAdapter,
-        'SKLearnL2': SKLearnL2Adapter,
-        'VPTreeL2Index': pynear.VPTreeL2Index,
-        'VPTreeL1Index': pynear.VPTreeL1Index,
-        'VPTreeBinaryIndex': pynear.VPTreeBinaryIndex,
-        'VPTreeChebyshevIndex': pynear.VPTreeChebyshevIndex
+        "FaissIndexFlatL2": FaissIndexFlatL2Adapter,
+        "FaissIndexBinaryFlat": FaissIndexBinaryFlatAdapter,
+        "AnnoyL2": AnnoyL2Adapter,
+        "AnnoyManhattan": AnnoyManhattanAdapter,
+        "AnnoyHamming": AnnoyHammingAdapter,
+        "SKLearnL2": SKLearnL2Adapter,
+        "VPTreeL2Index": pynear.VPTreeL2Index,
+        "VPTreeL1Index": pynear.VPTreeL1Index,
+        "VPTreeBinaryIndex": pynear.VPTreeBinaryIndex,
+        "VPTreeChebyshevIndex": pynear.VPTreeChebyshevIndex,
     }
     if index_name not in mapper:
-        raise ValueError(f'Index name {index_name} not supported')
+        raise ValueError(f"Index name {index_name} not supported")
 
-    if index_name.startswith('VPTree'):
+    if index_name.startswith("VPTree"):
         return PyNearAdapter(index_name)
 
     return mapper[index_name]()
@@ -32,7 +35,6 @@ def create_index_adapter(index_name: str):
 
 # Supported 3rd party indices are: FaissIndexFlatL2, FaissIndexBinaryFlat, AnnoyL2, AnnoyManhattan, AnnoyHamming, SKLearnL2
 class IndexAdapter(ABC):
-
     @abstractmethod
     def build_index(self, data: np.ndarray):
         pass
@@ -51,15 +53,14 @@ class IndexAdapter(ABC):
 
 
 class PyNearAdapter(IndexAdapter):
-
     def __init__(self, pyvp_index_name: str):
         self._index = None
         self._pyvp_index_name = pyvp_index_name
         self._pyvp_index_map = {
-            'VPTreeL2Index': pynear.VPTreeL2Index,
-            'VPTreeBinaryIndex': pynear.VPTreeBinaryIndex,
-            'VPTreeChebyshevIndex': pynear.VPTreeChebyshevIndex,
-            'VPTreeL1Index': pynear.VPTreeL1Index
+            "VPTreeL2Index": pynear.VPTreeL2Index,
+            "VPTreeBinaryIndex": pynear.VPTreeBinaryIndex,
+            "VPTreeChebyshevIndex": pynear.VPTreeChebyshevIndex,
+            "VPTreeL1Index": pynear.VPTreeL1Index,
         }
 
     def build_index(self, data: np.ndarray):
@@ -71,7 +72,6 @@ class PyNearAdapter(IndexAdapter):
 
 
 class FaissIndexFlatL2Adapter(IndexAdapter):
-
     def __init__(self):
         self._index = None
 
@@ -85,7 +85,6 @@ class FaissIndexFlatL2Adapter(IndexAdapter):
 
 
 class FaissIndexBinaryFlatAdapter(IndexAdapter):
-
     def __init__(self):
         self._index = None
 
@@ -99,13 +98,12 @@ class FaissIndexBinaryFlatAdapter(IndexAdapter):
 
 
 class AnnoyL2Adapter(IndexAdapter):
-
     def __init__(self):
         self._index = None
         pass
 
     def build_index(self, data: np.ndarray):
-        self._index = annoy.AnnoyIndex(data.shape[1], 'euclidean')
+        self._index = annoy.AnnoyIndex(data.shape[1], "euclidean")
         for i, v in enumerate(data):
             self._index.add_item(i, v)
 
@@ -117,12 +115,11 @@ class AnnoyL2Adapter(IndexAdapter):
 
 
 class AnnoyManhattanAdapter(IndexAdapter):
-
     def __init__(self):
         self._index = None
 
     def build_index(self, data: np.ndarray):
-        self._index = annoy.AnnoyIndex(data.shape[1], 'manhattan')
+        self._index = annoy.AnnoyIndex(data.shape[1], "manhattan")
         for i, v in enumerate(data):
             self._index.add_item(i, v)
 
@@ -132,12 +129,11 @@ class AnnoyManhattanAdapter(IndexAdapter):
 
 
 class AnnoyHammingAdapter(IndexAdapter):
-
     def __init__(self):
         self._index = None
 
     def build_index(self, data: np.ndarray):
-        self._index = annoy.AnnoyIndex(data.shape[1], 'hamming')
+        self._index = annoy.AnnoyIndex(data.shape[1], "hamming")
         for i, v in enumerate(data):
             self._index.add_item(i, v)
 
@@ -149,7 +145,6 @@ class AnnoyHammingAdapter(IndexAdapter):
 
 
 class SKLearnL2Adapter(IndexAdapter):
-
     def __init__(self):
         self._index = None
 
@@ -167,7 +162,7 @@ class SKLearnL2Adapter(IndexAdapter):
         """
         # sklearn uses index based on k, so need to build on the fly
         # we will not clock index training stage
-        self._index = NearestNeighbors(n_neighbors=k, algorithm='kd_tree', metric='euclidean')
+        self._index = NearestNeighbors(n_neighbors=k, algorithm="kd_tree", metric="euclidean")
         self._index.fit(self._data)
 
         s = time.time()

--- a/pynear/benchmark/run_benchmarks.py
+++ b/pynear/benchmark/run_benchmarks.py
@@ -1,38 +1,31 @@
-
-import os
-import sys
 import argparse
-from pynear.logging import create_and_configure_log
-
-from pynear.benchmark import BenchmarkCase
-from pynear.benchmark import BenchmarkRunner
+import os
 
 import matplotlib.pyplot as plt
-from matplotlib.ticker import AutoMinorLocator
 import pandas as pd
-import seaborn as sns
-import yaml
+
+from pynear.benchmark import BenchmarkRunner
+from pynear.logging import create_and_configure_log
 
 logger = create_and_configure_log(__name__)
 
 
 def create_performance_plot(result: pd.DataFrame, case_name: str, output_folder: str):
-
     groups = result.groupby("k")
 
     for k, group in groups:
         index_types = group.groupby("index_type")
         for index_type, df in index_types:
-
             # create one plot per k
             # resetting index before melting to save the current index in 'index' column...
-            plt.plot([str(v) for v in df["dimension"]], df["time"], label=index_type, marker='o')
+            plt.plot([str(v) for v in df["dimension"]], df["time"], label=index_type, marker="o")
             data_size = df.iloc[0]["dataset_total_size"]
             query_size = df.iloc[0]["num_queries"]
             num_avg_searchs = df.iloc[0]["num_seraches_avg"]
             plt.title(
-                f"{case_name}\nData Dimensions x Query Time (avg of {num_avg_searchs})\ndata_size={data_size}), k={k}\nquery_size={query_size})")
-            plt.legend(loc='upper center')
+                f"{case_name}\nData Dimensions x Query Time (avg of {num_avg_searchs})\ndata_size={data_size}), k={k}\nquery_size={query_size})"
+            )
+            plt.legend(loc="upper center")
 
         plt.tight_layout()
         plt.savefig(os.path.join(output_folder, f"result_k={k}.png"))
@@ -40,7 +33,6 @@ def create_performance_plot(result: pd.DataFrame, case_name: str, output_folder:
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Creates a stress test report for a segemaker endpoint")
     parser.add_argument(
         "--config-file",

--- a/pynear/include/DistanceFunctions.hpp
+++ b/pynear/include/DistanceFunctions.hpp
@@ -85,8 +85,7 @@ template <> int64_t hamming_u64<64>(const uint64_t *pa, const uint64_t *pb) { re
 
 template <> int64_t hamming_u64<128>(const uint64_t *pa, const uint64_t *pb) {
 
-    __m256d result =
-        _mm256_set_pd(_mm_popcnt_u64(pa[0] ^ pb[0]), _mm_popcnt_u64(pa[1] ^ pb[1]), 0, 0);
+    __m256d result = _mm256_set_pd(_mm_popcnt_u64(pa[0] ^ pb[0]), _mm_popcnt_u64(pa[1] ^ pb[1]), 0, 0);
     return (int64_t)sum4(result);
 }
 

--- a/pynear/include/VPTree.hpp
+++ b/pynear/include/VPTree.hpp
@@ -72,7 +72,7 @@ template <typename T, typename distance_type, distance_type (*distance)(const T 
     void set(const std::vector<T> &array) {
         clear();
 
-        if(array.empty()) {
+        if (array.empty()) {
             return;
         }
 

--- a/pynear/tests/test_serialization.py
+++ b/pynear/tests/test_serialization.py
@@ -15,7 +15,7 @@ def test_empty_index_serialization():
     # not initializing data with .set() should
     # be equivalent of initializing with empty array
     vptree = pynear.VPTreeL2Index()
-    empty = np.array([]).reshape(-1,8)
+    empty = np.array([]).reshape(-1, 8)
     vptree.set(empty)
     data = pickle.dumps(vptree)
     recovered = pickle.loads(data)
@@ -27,6 +27,7 @@ def test_empty_index_serialization():
     recovered = pickle.loads(data)
     data_rec = pickle.dumps(recovered)
     assert data_rec == data
+
 
 def test_basic_serialization():
     np.random.seed(seed=42)
@@ -52,6 +53,7 @@ def test_basic_serialization():
     vptree_indices_rec, vptree_distances_rec = recovered.search1NN(queries)
     assert vptree_indices_rec == vptree_indices and vptree_distances_rec == vptree_distances
 
+
 def test_string_serialization():
     np.random.seed(seed=42)
 
@@ -70,6 +72,7 @@ def test_string_serialization():
     restored_string_state = restored.to_string()
 
     assert restored_string_state == string_state
+
 
 def test_binary_serialization():
     np.random.seed(seed=42)

--- a/pynear/tests/test_vptree.py
+++ b/pynear/tests/test_vptree.py
@@ -5,7 +5,8 @@
 
 from collections import Counter
 from functools import partial
-from typing import Callable, Tuple
+from typing import Callable
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -54,7 +55,7 @@ def test_empty_index():
 
     try:
         vptree = pynear.VPTreeL2Index()
-        empty = np.array([]).reshape(-1,2)
+        empty = np.array([]).reshape(-1, 2)
         vptree.set(empty)
         i, d = vptree.search1NN(np.random.rand(1, 8).astype(dtype=np.uint8))
         assert False

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-import os
 import sys
 
-from pybind11.setup_helpers import Pybind11Extension, build_ext
-from setuptools import find_packages, setup
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import find_packages
+from setuptools import setup
 
 if sys.platform == "win32":
     extra_compile_args = ["/Wall", "/arch:AVX", "/openmp"]  # /LTCG unrecognized here
@@ -31,7 +31,7 @@ with open("README.md", "rt", encoding="utf-8") as fr:
 exec(open("pynear/_version.py").read())
 setup(
     name="pynear",
-    version=__version__,
+    version=__version__,  # noqa: F821
     packages=find_packages(),
     author="Pablo Carneiro Elias",
     author_email="pablo.cael@gmail.com",


### PR DESCRIPTION
This PR introduces a few diverse changes:
- Update README to explain more broadly the goal of pynear instead of directly focus on vptrees (consider vptrees as part of the set of algorithms and not the only one).
- Change Makefile formatter to use clang-formater for cpp + isort + flake and black so to mimic pre commit hook. Stylize is not used anymore now.
- Apply new formatter to code and fix linting issues (several).

