### PR TITLE
release: 2.3.1 — parallel MIH + corrected binary benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to PyNear are documented in this file. Versioning follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html): MAJOR.MINOR.PATCH.
 
-## Unreleased
+## 2.3.1 — 2026-05-25
 
 ### Added
 

--- a/pynear/_version.py
+++ b/pynear/_version.py
@@ -3,6 +3,6 @@
 _version = {
     "major": 2,
     "minor": 3,
-    "revis": 0,
+    "revis": 1,
 }
 __version__ = ".".join([str(a) for a in _version.values()])


### PR DESCRIPTION
Bundles the merged work since 2.3.0:
- OpenMP parallel-for in MIHBinaryIndex.searchKNN
- corrected binary-descriptor benchmark claims (reproducible, thread-matched vs Faiss IndexBinaryFlat and IndexBinaryMultiHash)
- MIH section in docs/approximate.md; demo_faiss_comparison.py + results
- demo_binary.py standard recall@k