### PR TITLE
ci: fix build-wheels failure from numpy dropping manylinux2014 wheels

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,6 +25,15 @@ jobs:
         CIBW_ARCHS_LINUX: auto64
         CIBW_ARCHS_WINDOWS: auto64
         CIBW_BEFORE_ALL_MACOS: brew install llvm libomp
+        # The wheel test runs inside the manylinux2014 (glibc 2.17) image,
+        # whose GCC is 10.2.1. numpy >= 2.3 dropped manylinux2014 wheels
+        # (it ships manylinux_2_28 only), so pip would fall back to building
+        # numpy from source in the test venv — and numpy's meson build
+        # requires GCC >= 10.3, which the image doesn't have. Pre-install a
+        # numpy that still publishes manylinux2014 wheels so the smoke test
+        # installs a binary instead of compiling from source. This only
+        # affects the CI test environment, not the numpy users get at runtime.
+        CIBW_BEFORE_TEST_LINUX: pip install "numpy<2.3"
         # Include both Homebrew prefixes: /opt/homebrew (arm64) and /usr/local (x86_64/Rosetta)
         CIBW_ENVIRONMENT_MACOS: >-
           CC="clang" CXX="clang++"


### PR DESCRIPTION
## What

Adds `CIBW_BEFORE_TEST_LINUX: pip install "numpy<2.3"` to the `build-wheels` job in `.github/workflows/pythonpackage.yml`.

## Why

`build-wheels (ubuntu-latest)` started failing on the README-only pushes to `main` on 2026-07-05, even though nothing in the package changed since the green v2.6.0 release on 2026-07-03.

The wheels themselves build fine. The failure is in cibuildwheel's **post-build test step**: it installs the freshly built wheel (with its `numpy>=1.21.2` runtime dependency) into a venv **inside the `manylinux2014` / glibc 2.17 container**. A newly released numpy (`2.5.1`) no longer publishes `manylinux2014` wheels — numpy went `manylinux_2_28`-only as of 2.3 — so pip fell back to building numpy from source, which fails against the container's GCC 10.2.1:

```
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
```

macOS and Windows were unaffected because they resolve modern numpy wheels normally; only the old-glibc Linux test container hit the source build.

## Fix

Pre-install a numpy that still ships `manylinux2014` wheels (`numpy<2.3`) into the Linux test environment, so the smoke test installs a binary instead of compiling from source.

This is **test-environment only**:
- It does not change the numpy end users resolve at runtime (`install_requires` is untouched).
- It keeps pynear's `manylinux2014` wheel compatibility unchanged.

Note (out of scope): the "version already exists" theory doesn't apply here — the `upload-pypi`/`create-release` jobs are gated on `refs/tags/v*` and never run on a `main` push.
